### PR TITLE
RFC 3161 Trusted Timestamping – Schema-Grundlage (Draft, Teil 1/2)

### DIFF
--- a/src/backend/database/models.py
+++ b/src/backend/database/models.py
@@ -8,7 +8,7 @@ GoBD-relevante Tabellen sind unveränderbar (immutable=True + Signatur).
 from datetime import date, datetime
 from decimal import Decimal
 from sqlalchemy import (
-    Boolean, Date, DateTime, ForeignKey, Integer, Numeric,
+    Boolean, Date, DateTime, ForeignKey, Integer, LargeBinary, Numeric,
     String, Text, UniqueConstraint, func,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -326,6 +326,11 @@ class Tagesabschluss(Base):
     benutzer: Mapped[str | None] = mapped_column(String(100))
     immutable: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     signatur: Mapped[str | None] = mapped_column(String(64))
+    # RFC 3161 Trusted Timestamping – optional, additiv zur SHA-256-Kette.
+    # Alle Felder NULL, wenn nicht angefordert oder TSA offline (Kette bleibt intakt).
+    tsa_zeitstempel_tsr: Mapped[bytes | None] = mapped_column(LargeBinary)  # vollständige RFC-3161-Response (.tsr)
+    tsa_zeitpunkt: Mapped[datetime | None] = mapped_column(DateTime)         # von der TSA bestätigter Zeitpunkt
+    tsa_quelle: Mapped[str | None] = mapped_column(String(255))              # TSA-Dienst, z.B. "freetsa.org"
     erstellt_am: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
 
 

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -33,7 +33,7 @@ logging.root.addHandler(_log_handler)
 from database.seed import run_all_seeds
 from api import unternehmen, konten, kategorien, setup, journal, kunden, lieferanten, tagesabschluss, nummernkreise, export, rechnungen, backup, artikel, artikel_gruppen, ust_saetze, pdf_vorlagen, eks, system, ustva, zm, euer, dokumentenpakete, mail, wiederkehrend, buchungsvorlagen, anlageverzeichnis, datev, anlage_s, anlage_g, fristen_api, guv, bank_templates, bank_import, auto_filter, forderungen, cockpit, datenmigration, kontenuebersicht, schnellbuchungen
 
-SCHEMA_VERSION = 121
+SCHEMA_VERSION = 122
 
 app = FastAPI(title="RechnungsFee API", version="0.1.0")
 
@@ -2607,6 +2607,21 @@ def _run_migrations() -> None:
             conn.execute(text("PRAGMA user_version = 121"))
             conn.commit()
             print("[Migration] Schema auf Version 121 (Abschreibungen (AfA): euer_zeile 36→33, Issue #265)")
+
+        if version < 122:
+            # RFC 3161 Trusted Timestamping – optionale, additive Felder auf tagesabschluesse.
+            # Kein Eingriff in die SHA-256-Kette; alle Felder bleiben NULL bis ein Zeitstempel vorliegt.
+            cols = {row[1] for row in conn.execute(text("PRAGMA table_info(tagesabschluesse)"))}
+            for col_name, ddl in [
+                ("tsa_zeitstempel_tsr", "BLOB"),
+                ("tsa_zeitpunkt",       "DATETIME"),
+                ("tsa_quelle",          "VARCHAR(255)"),
+            ]:
+                if col_name not in cols:
+                    conn.execute(text(f"ALTER TABLE tagesabschluesse ADD COLUMN {col_name} {ddl}"))
+            conn.execute(text("PRAGMA user_version = 122"))
+            conn.commit()
+            print("[Migration] Schema auf Version 122 (RFC 3161 TSA-Felder auf tagesabschluesse)")
 
 
 def _migrate_kategorien() -> None:

--- a/src/backend/tests/test_migrations.py
+++ b/src/backend/tests/test_migrations.py
@@ -176,7 +176,8 @@ class TestMigrationen:
         assert {"bezahlt_betrag", "zahlungsstatus", "leistung_von", "leistung_bis",
                 "ist_entwurf", "storniert", "ausgegeben"} <= get_columns(db_path, "rechnungen")
         # tagesabschluesse
-        assert {"zaehlung_json", "signatur"} <= get_columns(db_path, "tagesabschluesse")
+        assert {"zaehlung_json", "signatur",
+                "tsa_zeitstempel_tsr", "tsa_zeitpunkt", "tsa_quelle"} <= get_columns(db_path, "tagesabschluesse")
         # unternehmen
         assert {"handelsregister_nr", "handelsregister_gericht", "logo_pfad",
                 "mail_betreff_vorlage", "mail_text_vorlage",


### PR DESCRIPTION
## Überblick

Dieser Draft-PR ist die **erste, rein additive Stufe** der RFC-3161-Erweiterung aus Discussion #32. Er legt **nur die Datenbank-Grundlage** – drei optionale, NULL-fähige Felder auf `tagesabschluesse` – und **berührt die bestehende SHA-256-Kette nicht**.

Als Draft gedacht: Diskussionsfläche, nicht zum Merge. Die eigentliche TSA-Aufruf-Logik kommt bewusst **separat in Teil 2**, nach deinem Review dieser Grundlage.

## Was dieser PR macht (Teil 1 – Schema)

- **`models.py`** – drei neue Felder auf `Tagesabschluss`, alle NULL-fähig:
  - `tsa_zeitstempel_tsr` (`LargeBinary`/BLOB) – die vollständige RFC-3161-Response (`.tsr`), der eigentliche Nachweis
  - `tsa_zeitpunkt` (`DateTime`) – der von der TSA bestätigte Zeitpunkt
  - `tsa_quelle` (`String(255)`) – welcher TSA-Dienst (z. B. `freetsa.org`)
- **`main.py`** – Migration auf Schema-Version 122, idempotentes `ALTER TABLE` nach dem etablierten Muster (`PRAGMA table_info` → `not in cols` → `ADD COLUMN`)
- **`test_migrations.py`** – bestehende Spalten-Assertion für `tagesabschluesse` um die drei Felder erweitert

## Was dieser PR bewusst NICHT macht

- **Keine TSA-Aufruf-Logik** – kein Netzwerkaufruf, keine Änderung an `create_tagesabschluss`
- **Kein Eingriff in `signatur.py`** – die Hash-Kette bleibt Zeile für Zeile unangetastet
- **Kein retroaktives Nachstempeln** – siehe Design-Entscheidungen

## Deine vier Anforderungen

| # | Anforderung | Status in diesem PR |
|---|---|---|
| 1 | Offline-Fallback | Schema unterstützt es (Felder bleiben NULL); die Logik folgt in Teil 2 |
| 2 | SHA-256-Kette unverändert | ✅ erfüllt – kein Zugriff auf die Kette |
| 3 | DB-Migration nach `main.py`-Muster | ✅ erfüllt |
| 4 | Test für Offline-Fallback | hier: Migrations-Test; der Offline-Fallback-Test kommt mit der Aufruf-Logik in Teil 2 |

## Design-Entscheidungen (Bitte um dein OK)

1. **Additiv, kein Ersatz:** Der TSA bekommt den fertigen SHA-256-Hash aus `signatur_tagesabschluss()`. Neue Spalten, kein Eingriff in die Kette.
2. **Kein retroaktives Backfill:** Alt-Datensätze (vor TSA) behalten NULL. Grund: Der TSA-Zeitpunkt ist der *Stempel*-Zeitpunkt, nicht der *Buchungs*-Zeitpunkt – nachträgliches Stempeln wäre GoBD-irreführend. Die DB enthält dann dauerhaft eine gemischte Population (gestempelt / NULL), die im späteren Prüfbericht klar unterscheidbar sein muss.
3. **Opt-in, Standard AUS (geplant für Teil 2):** Das Feature soll standardmäßig deaktiviert sein – „aus" == „offline" == NULL-Felder, keine Sonderlogik. Ohne Aktivierung bleibt die DB unverändert.
4. **Spaltennamen/Typen:** deutsch gehalten. `tsa_seriennummer` bewusst weggelassen – für Laien ohne Aussagekraft und aus der `.tsr` jederzeit ableitbar.

## Offene Fragen

1. Passen die Spaltennamen/-typen für dich?
2. Gibt es eine Issue-Nummer, auf die die Migration verweisen soll? (Du koppelst Migrationen sonst an Issues.)
3. Bestätigst du „kein retroaktives Backfill"?
4. Für Teil 2: TSA-Aufruf synchron oder asynchron? Timeout-Wert? Wo gehört der Aktiv-Schalter hin (Einstellungen)?
5. Langfristig (LTV): Die 8-jährige GoBD-Aufbewahrung überlebt Hash-Algorithmen und TSA-Zertifikate – soll ein Erneuerungsmechanismus in den Scope?

## Kontext

Basiert auf Discussion #32. Ein lauffähiger Referenz-PoC (openssl + curl, FreeTSA) liegt separat vor.
